### PR TITLE
fix: 7 post-merge bugs from PR #48 code review

### DIFF
--- a/syda/codegen_cache.py
+++ b/syda/codegen_cache.py
@@ -94,7 +94,8 @@ class CodegenCache:
                 pass
 
             return {"simple": simple_fns, "simple_source": simple_source}
-        except Exception:
+        except Exception as e:
+            print(f"[syda] Warning: codegen cache load failed ({e}), treating as cache miss")
             return None
 
     def save(

--- a/syda/generate.py
+++ b/syda/generate.py
@@ -679,7 +679,7 @@ class SyntheticDataGenerator:
 
                 # Slim to FK columns; fully drop if nobody references this table.
                 fk_cols = list(fk_exposed.get(schema_name, set()) & set(df.columns))
-                df = df[fk_cols] if fk_cols else pd.DataFrame(columns=list(df.columns)[:0])
+                df = df[fk_cols] if fk_cols else pd.DataFrame(columns=list(df.columns))
 
             results[schema_name] = df
 
@@ -699,7 +699,7 @@ class SyntheticDataGenerator:
                         fk_cols = list(fk_exposed.get(parent, set()) & set(results[parent].columns))
                         results[parent] = (
                             results[parent][fk_cols] if fk_cols
-                            else pd.DataFrame(columns=list(results[parent].columns)[:0])
+                            else pd.DataFrame(columns=list(results[parent].columns))
                         )
 
         return results, streamed_schemas
@@ -1036,10 +1036,12 @@ Every column must appear in exactly one list."""
             print(f"[syda] Code-gen cache HIT for '{schema_name}' (hash {schema_hash})")
             # simple holds callables; derive semantic = columns with no generator
             simple_fns: Dict[str, Any] = {
-                k: v for k, v in cached.get("simple", {}).items() if k not in forced_semantic
+                k: v for k, v in cached.get("simple", {}).items()
+                if k not in forced_semantic and k not in pre_registered
             }
             simple_source: Dict[str, str] = {
-                k: v for k, v in cached.get("simple_source", {}).items() if k not in forced_semantic
+                k: v for k, v in cached.get("simple_source", {}).items()
+                if k not in forced_semantic and k not in pre_registered
             }
             semantic_cols: List[str] = [
                 col for col in table_schema
@@ -1084,7 +1086,8 @@ Every column must appear in exactly one list."""
                     if fn:
                         simple_fns[col_name] = fn
                 except Exception as e:
-                    print(f"[syda] Warning: could not compile generator for '{col_name}': {e}")
+                    print(f"[syda] Warning: generator for '{col_name}' failed at runtime ({e}), falling back to LLM")
+                    semantic_cols.append(col_name)
 
             if cache and schema_hash:
                 cache.save(
@@ -1385,8 +1388,19 @@ Every column must appear in exactly one list."""
                     )
                     if len(values) > sample_size:
                         values = values[:sample_size]
-                    while len(values) < sample_size:
-                        values.extend(values[:sample_size - len(values)])
+                    if len(values) < sample_size:
+                        col_schema = table_schema.get(col, {})
+                        is_unique = isinstance(col_schema, dict) and (col_schema.get("unique") or col_schema.get("primary_key"))
+                        if is_unique:
+                            print(f"[syda] Warning: semantic column '{col}' returned {len(values)}/{sample_size} values; padding with index-suffixed duplicates to preserve uniqueness")
+                            base = list(values)
+                            i = len(base)
+                            while len(values) < sample_size:
+                                values.append(f"{base[i % len(base)]}_{i}")
+                                i += 1
+                        else:
+                            while len(values) < sample_size:
+                                values.extend(values[:sample_size - len(values)])
                     df[col] = values[:sample_size]
 
             df = self._enforce_uniqueness(df, table_schema, metadata, chunk_offset=0)
@@ -1408,7 +1422,7 @@ Every column must appear in exactly one list."""
             remaining = sz
             topup_attempts = 0
 
-            while remaining > 0 and topup_attempts <= effective_retries:
+            while remaining > 0 and topup_attempts < effective_retries:
                 p = self._build_prompt(table_schema, metadata, table_description,
                                        primary_key_fields, prompt, remaining)
                 result = self._call_with_retry(


### PR DESCRIPTION
## Summary

Applies 7 bug fixes that were identified by code review of PR #48 but committed after the merge. All fixes verified: 225 unit tests pass, pre-release script passes clean.

- **`generate.py`**: `list(df.columns)[:0]` produced zero-column DataFrames when slimming tables with no FK children, silently breaking FK sampling for child tables
- **`generate.py`**: Cache-HIT path didn't exclude `pre_registered` FK columns from `simple_fns`, causing FK sampler generators to be overwritten by codegen functions on repeated runs
- **`generate.py`**: `exec()` failure for a codegen column silently dropped the column from output entirely — now falls back to LLM semantic generation
- **`generate.py`**: Semantic padding for unique-constrained columns used duplicate values, violating the uniqueness constraint — now pads with index-suffixed values; also guards against `str` col_schema (simplified schema format)
- **`generate.py`**: Off-by-one in top-up retry loop (`<=` → `<`) allowed one extra iteration beyond `max_retries`
- **`codegen_cache.py`**: `exec()` runtime failures returned `None` silently — now logs the exception before treating as cache miss

## Test plan

- [x] 225 unit tests pass (`pytest`)
- [x] Pre-release script passes all checks (`bash scripts/pre_release_test.sh`)
- [x] All examples run clean (force_llm, CLI large dataset, structured_only, quickstart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)